### PR TITLE
Localize Vue component placeholders and validation messages

### DIFF
--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -441,3 +441,24 @@ msgstr "CODECHECK"
 
 msgid "plugins.generic.codecheck.certificate.viewLink"
 msgstr "View Certificate"
+
+msgid "plugins.generic.codecheck.repository.placeholder"
+msgstr "https://github.com/username/repo"
+
+msgid "plugins.generic.codecheck.repository.addButton"
+msgstr "+ Add URL"
+
+msgid "plugins.generic.codecheck.repository.validation.protocol"
+msgstr "URL must start with http:// or https://"
+
+msgid "plugins.generic.codecheck.repository.validation.invalid"
+msgstr "Please enter a valid URL"
+
+msgid "plugins.generic.codecheck.manifestFiles.filenamePlaceholder"
+msgstr "Filename (e.g., figures/figure1.png)"
+
+msgid "plugins.generic.codecheck.manifestFiles.commentPlaceholder"
+msgstr "Comment (e.g., Main result visualization)"
+
+msgid "plugins.generic.codecheck.manifestFiles.addButton"
+msgstr "+ Add File"

--- a/resources/js/Components/CodecheckManifestFiles.vue
+++ b/resources/js/Components/CodecheckManifestFiles.vue
@@ -5,14 +5,14 @@
         <input
           v-model="file.filename"
           type="text"
-          placeholder="Filename (e.g., figures/figure1.png)"
+          :placeholder="t('plugins.generic.codecheck.manifestFiles.filenamePlaceholder')"
           @input="updateValue"
           class="form-control"
         />
         <input
           v-model="file.comment"
           type="text"
-          placeholder="Comment (e.g., Main result visualization)"
+          :placeholder="t('plugins.generic.codecheck.manifestFiles.commentPlaceholder')"
           @input="updateValue"
           class="form-control"
         />
@@ -20,7 +20,7 @@
       </div>
     </div>
     <button type="button" @click="addFile" class="btn-add">
-      + Add File
+      {{ t('plugins.generic.codecheck.manifestFiles.addButton') }}
     </button>
   </div>
 </template>

--- a/resources/js/Components/CodecheckRepositoryList.vue
+++ b/resources/js/Components/CodecheckRepositoryList.vue
@@ -5,7 +5,7 @@
         <input
           v-model="repositories[index]"
           type="url"
-          placeholder="https://github.com/username/repo"
+          :placeholder="t('plugins.generic.codecheck.repository.placeholder')"
           @input="updateValue"
           @blur="validateUrl(index)"
           :class="['form-control', { 'is-invalid': errors[index] }]"
@@ -17,7 +17,7 @@
       </div>
     </div>
     <button type="button" @click="addRepository" class="btn-add">
-      + Add URL
+      {{ t('plugins.generic.codecheck.repository.addButton') }}
     </button>
   </div>
 </template>
@@ -68,12 +68,12 @@ function validateUrl(index) {
   try {
     new URL(url);
     if (!url.startsWith('http://') && !url.startsWith('https://')) {
-      errors.value[index] = 'URL must start with http:// or https://';
+      errors.value[index] = t('plugins.generic.codecheck.repository.validation.protocol');
     } else {
       errors.value[index] = '';
     }
   } catch {
-    errors.value[index] = 'Please enter a valid URL';
+    errors.value[index] = t('plugins.generic.codecheck.repository.validation.invalid');
   }
 }
 


### PR DESCRIPTION
- Localize repository URL placeholder and validation messages
- Localize manifest file placeholders and button text
- Add required locale keys for all user-facing strings

Closes #78
---

## Related User Stories

- A-ME1 (related): As an author, I want to enter CODECHECK-related metadata (code URL, data URL, expected outputs) only once...
- A-GV1 (related): As an author, I want inline guidance, examples, and validation in the submission form...

_User story references from the [CHECK-PUB User Stories document](https://codecheck.org.uk/pub/)._