### PR TITLE
fix: replace getOptIn() with article->getData('codecheckOptIn')

### DIFF
--- a/classes/FrontEnd/ArticleDetails.php
+++ b/classes/FrontEnd/ArticleDetails.php
@@ -56,7 +56,11 @@ class ArticleDetails
         $codecheckData = $dao->getBySubmissionId($article->getId());
 
         // Only show CODECHECK info if user opted in
-        if (!$codecheckData || !$codecheckData->getOptIn()) {
+        if (!$article->getData('codecheckOptIn')) {
+            return false;
+        }
+
+        if (!$codecheckData) {
             return false;
         }
 


### PR DESCRIPTION
`CodecheckSubmission` has no `getOptIn()` method. The opt-in flag is stored on the submission object, not in `codecheck_metadata`. Replaced `$codecheckData->getOptIn()` with `$article->getData('codecheckOptIn')` to match how `IssueTOC` handles it correctly.
---

## Related User Stories

- A-SO1 (related): As an author, I want to opt in to a CODECHECK during submission and communicate with the codechecker...

_User story references from the [CHECK-PUB User Stories document](https://codecheck.org.uk/pub/)._