### PR TITLE
fix settings form, compatible with #109

### DIFF
--- a/CodecheckPlugin.php
+++ b/CodecheckPlugin.php
@@ -5,6 +5,7 @@ use APP\core\Application;
 use APP\template\TemplateManager;
 use APP\plugins\generic\codecheck\classes\FrontEnd\ArticleDetails;
 use APP\plugins\generic\codecheck\classes\Settings\Actions;
+use APP\plugins\generic\codecheck\classes\Settings\Manage;
 use APP\plugins\generic\codecheck\classes\migration\CodecheckSchemaMigration;
 use APP\plugins\generic\codecheck\classes\Submission\Schema;
 use APP\plugins\generic\codecheck\classes\Submission\SubmissionWizardHandler;
@@ -13,6 +14,7 @@ use PKP\plugins\Hook;
 use PKP\components\forms\FieldOptions;
 use APP\facades\Repo;
 use APP\plugins\generic\codecheck\api\v1\CodecheckApiHandler;
+use PKP\core\JSONMessage;
 
 class CodecheckPlugin extends GenericPlugin
 {
@@ -245,6 +247,19 @@ class CodecheckPlugin extends GenericPlugin
     {
         $actions = new Actions($this);
         return $actions->execute($request, $actionArgs, parent::getActions($request, $actionArgs));
+    }
+
+    /**
+     * Load a form when the `settings` button is clicked and
+     * save the form when the user saves it.
+     *
+     * @param array $args
+     * @param Request $request
+     */
+    public function manage($args, $request): JSONMessage
+    {
+        $manage = new Manage($this);
+        return $manage->execute($args, $request);
     }
 
     public function setEnabled($enabled, $contextId = null)

--- a/templates/settings.tpl
+++ b/templates/settings.tpl
@@ -6,6 +6,7 @@
  *
  * Settings form for the CODECHECK plugin.
  *}
+
 <script>
 	$(function() {ldelim}
 		$('#codecheckSettings').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
@@ -16,29 +17,33 @@
 	class="pkp_form"
 	id="codecheckSettings"
 	method="POST"
-	action="{url router=$smarty.const.ROUTE_COMPONENT op="manage" category="generic" plugin=$pluginName verb="settings" save=true}"
+	action="{url router=$smarty.const.ROUTE_COMPONENT op='manage' category='generic' plugin=$pluginName verb='settings' save=true}"
 >
 	<!-- Always add the csrf token to secure your form -->
 	{csrf}
-	
-	<div class="pkp_form_description">
-		<p>{translate key="plugins.generic.codecheck.settings.description"}</p>
-	</div>
 
 	{fbvFormArea id="codecheckSettingsArea"}
-		{fbvFormSection}
+		{* CODECHECK Settings Heading *}
+		<h3 class="section-title">{translate key="plugins.generic.codecheck.settings.title"}</h3>
+		<p class="section-description">{translate key="plugins.generic.codecheck.settings.description"}</p>
+
+		{* Option to enable/ disable CODECHECK *}
+		{fbvFormSection
+			list=true
+		}
+			<div class="field-header">
+				<label class="pkp_form_label">{translate key="plugins.generic.codecheck.settings.enableCodecheck"}</label>
+			</div>
 			{fbvElement
 				type="checkbox"
 				id="codecheckEnabled"
 				checked=$codecheckEnabled
-				label="plugins.generic.codecheck.settings.codecheckEnabled"
-				description="plugins.generic.codecheck.settings.codecheckEnabled.description"
+				label="plugins.generic.codecheck.settings.enableCodecheck.description"
 			}
 		{/fbvFormSection}
-		
+
 		{* TODO: Add more settings in future development *}
 		{* - ORCID integration settings *}
-		{* - Repository connection settings *}
 		{* - Email template settings *}
 		
 	{/fbvFormArea}


### PR DESCRIPTION
There is no more error thrown when the settings form is opened.
---

## Related User Stories

- P-CS1 (related): As a journal manager, I want to configure the CODECHECK mode, submission form fields, and instructions...
- P-AS1 (related): As a publisher, I want to enable CODECHECK by installing the plugin and configuring settings...
- P-CS2 (related): As a publisher, I want to configure the CODECHECK badge image, logo, and placement...

_User story references from the [CHECK-PUB User Stories document](https://codecheck.org.uk/pub/)._