### PR TITLE
submission form - align ux of mandatory CODECHECK

### DIFF
--- a/CodecheckPlugin.php
+++ b/CodecheckPlugin.php
@@ -334,7 +334,7 @@ class CodecheckPlugin extends GenericPlugin
             $codecheckMode = $this->getSetting($context->getId(), Constants::CODECHECK_MODE);
             CodecheckLogger::debug('Mode: ' . $codecheckMode);
             $checkboxValue = false;
-            $checkboxDisabled = false;
+            $codecheckMandatory = false;
             $codecheckDescription = __('plugins.generic.codecheck.optIn.description', [
                 'codecheckLink' => "<a href='{$this->getUrlPageRoute("codecheck")}/info' target='_blank'>" . __('plugins.generic.codecheck.displayName') . "</a>"
             ]);
@@ -343,7 +343,7 @@ class CodecheckPlugin extends GenericPlugin
                 $checkboxValue = true;
             } elseif ($codecheckMode == 'mandatory') {
                 $checkboxValue = true;
-                $checkboxDisabled = true;
+                $codecheckMandatory = true;
                 $codecheckDescription = __('plugins.generic.codecheck.mandatory.description', [
                     'codecheckLink' => "<a href='{$this->getUrlPageRoute("codecheck")}/info' target='_blank'>" . __('plugins.generic.codecheck.displayName') . "</a>"
                 ]);
@@ -351,12 +351,13 @@ class CodecheckPlugin extends GenericPlugin
 
             $form->addField(new FieldOptions('codecheckOptIn', [
                 'label' => __('plugins.generic.codecheck.displayName'),
+                'isRequired' => $codecheckMandatory,
                 'type' => 'checkbox',
                 'options' => [
                     [
                         'value' => 1, 
                         'label' => $codecheckDescription,
-                        'disabled' => $checkboxDisabled,
+                        'disabled' => $codecheckMandatory,
                     ]
                 ],
                 'value' => $checkboxValue,

--- a/CodecheckPlugin.php
+++ b/CodecheckPlugin.php
@@ -363,8 +363,6 @@ class CodecheckPlugin extends GenericPlugin
                 'value' => $checkboxValue,
                 'groupId' => 'default'
             ]));
-            
-            return false;
         }
         
         return false;


### PR DESCRIPTION
Closes #128;

When not opted-in, it now looks like this:

<img width="508" height="91" alt="Image" src="https://github.com/user-attachments/assets/51a23cf2-e9ef-4b5e-8b0b-231ba67c783b" />

When opted-in it looks like this:

<img width="513" height="94" alt="Image" src="https://github.com/user-attachments/assets/075e0267-5937-49df-a9ff-75b90337f000" />

When mandatory it looks like this:

<img width="519" height="127" alt="Image" src="https://github.com/user-attachments/assets/913df20e-d47b-4c44-905d-229f9cc91af0" />