### PR TITLE
Feature/codecheck status

### DIFF
--- a/CodecheckPlugin.php
+++ b/CodecheckPlugin.php
@@ -115,15 +115,18 @@ class CodecheckPlugin extends GenericPlugin
 
     public function addCodecheckStatusLocalizations($hookName, $args) {
         $templateMgr = $args[0];
+
+        $localeKeys = array_combine(
+            Constants::CODECHECK_STATUSES,
+            array_map(fn($status) => __($status), Constants::CODECHECK_STATUSES)
+        );
+
+        $localeKeys[Constants::CODECHECK_STATUS_PENDING] = __(Constants::CODECHECK_STATUS_PENDING);
+
         $templateMgr->addJavaScript(
             'codecheck-locale-status',
             'pkp.localeKeys = pkp.localeKeys || {};' .
-            'Object.assign(pkp.localeKeys, ' . json_encode(
-                array_combine(
-                    Constants::CODECHECK_STATUSES,
-                    array_map(fn($status) => __($status), Constants::CODECHECK_STATUSES)
-                )
-            ) . ');',
+            'Object.assign(pkp.localeKeys, ' . json_encode($localeKeys) . ');',
             ['inline' => true, 'contexts' => ['backend']]
         );
         return false;

--- a/api/v1/CodecheckApiHandler.php
+++ b/api/v1/CodecheckApiHandler.php
@@ -611,6 +611,7 @@ class CodecheckApiHandler
         array $repositories
     ): array
     {
+        $updateInformation = $this->plugin->getSetting($this->request->getContext()->getId(), Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_FIELDS);
         // Add the new issue to the CODECHECK GtiHub Register
         $issue = $codecheckGithubRegisterApiClient->addIssue(
             $identifier,
@@ -618,7 +619,8 @@ class CodecheckApiHandler
             $articleTitle,
             $authorString,
             $codecheckers,
-            $repositories
+            $repositories,
+            $updateInformation
         );
 
         return $issue;
@@ -640,8 +642,9 @@ class CodecheckApiHandler
         array $repositories
     ): string
     {
-        $journalName = $this->request->getContext()?->getLocalizedName() ?? 'Unknwon Journal';
-
+        $context = $this->request->getContext();
+        $journalName = $context?->getLocalizedName() ?? 'Unknwon Journal';
+        $updateInformation = $this->plugin->getSetting($context->getId(), Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_FIELDS);
         $codecheckIssue = new CodecheckGithubRegisterIssue(
             $githubRegisterOrganization,
             $githubRegisterRepository,
@@ -652,7 +655,8 @@ class CodecheckApiHandler
             $authorString,
             $this->codecheckMetadataHandler->getSubmissionId(),
             $codecheckers,
-            $repositories
+            $repositories,
+            $updateInformation
         );
 
         return $codecheckIssue->getNewIssueUrl();

--- a/api/v1/CodecheckApiHandler.php
+++ b/api/v1/CodecheckApiHandler.php
@@ -972,15 +972,6 @@ class CodecheckApiHandler
 
         $statusRecord = CodecheckStatusHandler::getCurrentStatusData($submissionId);
 
-        if($statusRecord == null) {
-            JsonResponse::staticResponse([
-                'success' => false,
-                'error' => "There doesn't exist any Status in the OJS Databse for this submission Id yet.",
-                'statusRecord' => null,
-                'allStatuses' => Constants::CODECHECK_STATUSES,
-            ], 500);
-        }
-
         JsonResponse::staticResponse([
             'success' => true,
             'statusRecord' => $statusRecord,
@@ -990,14 +981,18 @@ class CodecheckApiHandler
 
     public function getStatusHistory(): void
     {
+        CodecheckLogger::debug("Get Status History");
         $submissionId = (int) $this->codecheckMetadataHandler->getSubmissionId();
 
         $statusHistory = CodecheckStatusHandler::getStatusDataHistory($submissionId);
 
-        if($statusHistory == null) {
+        CodecheckLogger::debug(print_r($statusHistory, true));
+
+        if(empty($statusHistory)) {
             JsonResponse::staticResponse([
                 'success' => false,
-                'statusHistory' => $statusHistory,
+                'error' => "Currently there is no recorded CODECHECK status history for this submission ID in the OJS database.",
+                'statusHistory' => null,
             ], 400);
         }
 
@@ -1038,13 +1033,13 @@ class CodecheckApiHandler
             }
             $statusUpdate = CodecheckStatusHandler::automaticStatusUpdate($submissionMetadata);
 
-            if($statusUpdate == null) {
+            if(empty($statusUpdate)) {
                 JsonResponse::staticResponse([
                     'success' => false,
                     'statusRecord' => $statusUpdate,
                     'allStatuses' => Constants::CODECHECK_STATUSES,
                     'error' => "Status doesn't need to be automatically updated."
-                ], 200);
+                ], 400);
             } else {
                 JsonResponse::staticResponse([
                     'success' => true,

--- a/classes/CodecheckRegister/CodecheckGithubRegisterApiClient.php
+++ b/classes/CodecheckRegister/CodecheckGithubRegisterApiClient.php
@@ -204,7 +204,8 @@ class CodecheckGithubRegisterApiClient
         string $paperTitle,
         string $authorString,
         array $codecheckers,
-        array $repositories
+        array $repositories,
+        array $updateInformation
     ): array {
         $this->client->authenticate($this->githubPAT, null, Client::AUTH_ACCESS_TOKEN);
 
@@ -218,7 +219,8 @@ class CodecheckGithubRegisterApiClient
             $authorString,
             $this->submissionID,
             $codecheckers,
-            $repositories
+            $repositories,
+            $updateInformation
         );
 
         try {
@@ -272,7 +274,8 @@ class CodecheckGithubRegisterApiClient
             $authorString,
             $this->submissionID,
             $codecheckers,
-            $repositories
+            $repositories,
+            $updateInformation
         );
 
         $issueContents = [];

--- a/classes/CodecheckRegister/CodecheckGithubRegisterIssue.php
+++ b/classes/CodecheckRegister/CodecheckGithubRegisterIssue.php
@@ -4,6 +4,7 @@ namespace APP\plugins\generic\codecheck\classes\CodecheckRegister;
 
 use APP\plugins\generic\codecheck\classes\CodecheckRegister\CertificateIdentifier;
 use APP\plugins\generic\codecheck\classes\CodecheckRegister\CodecheckIssueLabels;
+use APP\plugins\generic\codecheck\classes\Workflow\CodecheckStatusHandler;
 
 class CodecheckGithubRegisterIssue {
     private string $repositoryOwner;
@@ -13,6 +14,7 @@ class CodecheckGithubRegisterIssue {
     private string $submissionID;
     private array $labels;
     private string $jsonEncodedCodecheckMetadata;
+    private string $codecheckStatus;
 
     public function __construct(
         string $repositoryOwner,
@@ -29,6 +31,7 @@ class CodecheckGithubRegisterIssue {
         $this->repositoryOwner = $repositoryOwner;
         $this->repository = $repository;
         $this->submissionID = $submissionID;
+        $this->codecheckStatus = CodecheckStatusHandler::getCurrentStatusData($this->submissionID)->status;
         $authorString = empty($authorString) ? 'New CODECHECK' : $authorString;
         $this->title = $this->createTitleMarkdown($authorString, $certificateIdentifier);
         $this->jsonEncodedCodecheckMetadata = $this->createJsonEncodedCodecheckMetadataMarkdown($authorString, $certificateIdentifier, $journalName, $submissionID, $codecheckers, $repositories);
@@ -77,6 +80,7 @@ class CodecheckGithubRegisterIssue {
         . "```json\n"
         . "{"
         . "\n\t\"identifier\": \"" . $certificateIdentifier->toStr() . "\","
+        . "\n\t\"status\": \"" . $this->codecheckStatus . "\","
         . "\n\t\"repositories\": " . json_encode($repositories) . ","
         . "\n\t\"codecheckers\": " . json_encode($codecheckers) . ","
         . "\n\t\"links\": [],"
@@ -99,8 +103,9 @@ class CodecheckGithubRegisterIssue {
         return "<!-- Provide the title of your published paper or preprint -->\n## " . $paperTitle . "\n\n"
         . "<!-- Provide a link to your published paper or preprint, ideally with a DOI -->\n**Article:**\n\n"
         . "<!-- Information about the Journal in which the paper/ preprint is published -->\n**Journal:** " . $journalName . " *(Submission ID: " . $this->submissionID . ")*\n\n"
-        . "<!-- Provide a link to your code (and data) repository(s) (GitHub, GitLab, etc.) -->\n**Repositories:**\n"
-        . $repoStr;
+        . "<!-- Provide a link to your code (and data) repository(s) (GitHub, GitLab, etc.) -->\n**Repositories:**\n" . $repoStr . "\n\n"
+        . "<!-- The current status of the CODECHECK -->\n**CODECHECK Status:** "
+        . __($this->codecheckStatus) . "\n\n";
     }
 
     private function fillLabels(

--- a/classes/CodecheckRegister/CodecheckGithubRegisterIssue.php
+++ b/classes/CodecheckRegister/CodecheckGithubRegisterIssue.php
@@ -37,10 +37,11 @@ class CodecheckGithubRegisterIssue {
         $this->repositoryOwner = $repositoryOwner;
         $this->repository = $repository;
         $this->submissionID = $submissionID;
-        $this->codecheckStatus = CodecheckStatusHandler::getCurrentStatusData($this->submissionID)->status;
+        $this->codecheckStatus = '';
         $this->updateStatus = false;
         if(in_array(Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_STATUS, $updateInformation)) {
             $this->updateStatus = true;
+            $this->codecheckStatus = CodecheckStatusHandler::getCurrentStatusData($this->submissionID)->status;
         }
         $updateCodecheckStatus = $this->updateStatus ? 'true' : 'false';
         CodecheckLogger::debug("Record / Update Status: " . $updateCodecheckStatus);

--- a/classes/CodecheckRegister/CodecheckGithubRegisterIssue.php
+++ b/classes/CodecheckRegister/CodecheckGithubRegisterIssue.php
@@ -5,6 +5,10 @@ namespace APP\plugins\generic\codecheck\classes\CodecheckRegister;
 use APP\plugins\generic\codecheck\classes\CodecheckRegister\CertificateIdentifier;
 use APP\plugins\generic\codecheck\classes\CodecheckRegister\CodecheckIssueLabels;
 use APP\plugins\generic\codecheck\classes\Workflow\CodecheckStatusHandler;
+use APP\plugins\generic\codecheck\classes\Constants;
+use PKP\plugins\PluginRegistry;
+use APP\core\Application;
+use APP\plugins\generic\codecheck\classes\Log\CodecheckLogger;
 
 class CodecheckGithubRegisterIssue {
     private string $repositoryOwner;
@@ -15,6 +19,7 @@ class CodecheckGithubRegisterIssue {
     private array $labels;
     private string $jsonEncodedCodecheckMetadata;
     private string $codecheckStatus;
+    private bool $updateStatus;
 
     public function __construct(
         string $repositoryOwner,
@@ -26,12 +31,19 @@ class CodecheckGithubRegisterIssue {
         string $authorString,
         string $submissionID,
         array $codecheckers,
-        array $repositories
+        array $repositories,
+        array $updateInformation
     ){
         $this->repositoryOwner = $repositoryOwner;
         $this->repository = $repository;
         $this->submissionID = $submissionID;
         $this->codecheckStatus = CodecheckStatusHandler::getCurrentStatusData($this->submissionID)->status;
+        $this->updateStatus = false;
+        if(in_array(Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_STATUS, $updateInformation)) {
+            $this->updateStatus = true;
+        }
+        $updateCodecheckStatus = $this->updateStatus ? 'true' : 'false';
+        CodecheckLogger::debug("Record / Update Status: " . $updateCodecheckStatus);
         $authorString = empty($authorString) ? 'New CODECHECK' : $authorString;
         $this->title = $this->createTitleMarkdown($authorString, $certificateIdentifier);
         $this->jsonEncodedCodecheckMetadata = $this->createJsonEncodedCodecheckMetadataMarkdown($authorString, $certificateIdentifier, $journalName, $submissionID, $codecheckers, $repositories);
@@ -76,11 +88,12 @@ class CodecheckGithubRegisterIssue {
         array $repositories
     ): string
     {
+        $statusInformation = $this->updateStatus ? "\n\t\"status\": \"" . $this->codecheckStatus . "\"," : "";
         return "<details>\n<summary><h3>JSON encoded CODECHECK metadata</h3></summary>\n\n"
         . "```json\n"
         . "{"
         . "\n\t\"identifier\": \"" . $certificateIdentifier->toStr() . "\","
-        . "\n\t\"status\": \"" . $this->codecheckStatus . "\","
+        . $statusInformation
         . "\n\t\"repositories\": " . json_encode($repositories) . ","
         . "\n\t\"codecheckers\": " . json_encode($codecheckers) . ","
         . "\n\t\"links\": [],"
@@ -100,12 +113,13 @@ class CodecheckGithubRegisterIssue {
         foreach ($repositories as $repo) {
             $repoStr .= "\t- " . $repo . "\n";
         }
+        $statusInformation = $this->updateStatus ? "<!-- The current status of the CODECHECK -->\n**CODECHECK Status:** " . __($this->codecheckStatus) . "\n\n" : "";
+        
         return "<!-- Provide the title of your published paper or preprint -->\n## " . $paperTitle . "\n\n"
         . "<!-- Provide a link to your published paper or preprint, ideally with a DOI -->\n**Article:**\n\n"
         . "<!-- Information about the Journal in which the paper/ preprint is published -->\n**Journal:** " . $journalName . " *(Submission ID: " . $this->submissionID . ")*\n\n"
         . "<!-- Provide a link to your code (and data) repository(s) (GitHub, GitLab, etc.) -->\n**Repositories:**\n" . $repoStr . "\n\n"
-        . "<!-- The current status of the CODECHECK -->\n**CODECHECK Status:** "
-        . __($this->codecheckStatus) . "\n\n";
+        . $statusInformation;
     }
 
     private function fillLabels(

--- a/classes/Constants.php
+++ b/classes/Constants.php
@@ -68,6 +68,7 @@ class Constants
     public const CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_BODY = 'updateBody';
     # Codecheck Publication Validation
     # Codecheck Status
+    public const CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_STATUS = 'updateStatus';
     public const CODECHECK_STATUS = 'codecheckStatus';
     public const CODECHECK_STATUSES_SELECTED = 'codecheckStatusesSelected';
     public const CODECHECK_STATUS_KEYS_SELECTED = 'codecheckStatusKeysSelected';

--- a/classes/Constants.php
+++ b/classes/Constants.php
@@ -66,9 +66,9 @@ class Constants
     public const CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_FIELDS = 'codecheckGithubUpdateFields';
     public const CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_TITLE = 'updateTitle';
     public const CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_BODY = 'updateBody';
+    public const CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_STATUS = 'updateStatus';
     # Codecheck Publication Validation
     # Codecheck Status
-    public const CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_STATUS = 'updateStatus';
     public const CODECHECK_STATUS = 'codecheckStatus';
     public const CODECHECK_STATUSES_SELECTED = 'codecheckStatusesSelected';
     public const CODECHECK_STATUS_KEYS_SELECTED = 'codecheckStatusKeysSelected';

--- a/classes/Constants.php
+++ b/classes/Constants.php
@@ -26,6 +26,7 @@ class Constants
     /**
      * The possible Codecheck Statuses
      */
+    public const CODECHECK_STATUS_PENDING = 'plugins.generic.codecheck.status.pending';
     public const CODECHECK_STATUS_NEEDS_CODECHECKER = 'plugins.generic.codecheck.status.needsCodechecker';
     public const CODECHECK_STATUS_ASSIGNED_CODECHECKER = 'plugins.generic.codecheck.status.assignedCodechecker';
     public const CODECHECK_STATUS_STALLED_AUTHOR = 'plugins.generic.codecheck.status.stalled.author';

--- a/classes/Settings/SettingsForm.php
+++ b/classes/Settings/SettingsForm.php
@@ -151,6 +151,7 @@ class SettingsForm extends Form
         // Unpack so each checkbox gets its own template variable
         $this->setData(Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_TITLE, in_array(Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_TITLE, $updateFields));
         $this->setData(Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_BODY, in_array(Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_BODY, $updateFields));
+        $this->setData(Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_STATUS, in_array(Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_STATUS, $updateFields));
 
         $this->setData(
             Constants::CODECHECK_PUBLICATION_VALIDATION_EXTENDED,
@@ -181,6 +182,7 @@ class SettingsForm extends Form
             Constants::CODECHECK_SHOW_DASHBOARD_COLUMN,
             Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_TITLE,
             Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_BODY,
+            Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_STATUS,
             Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_FIELDS,
             Constants::CODECHECK_STATUS,
             Constants::CODECHECK_STATUSES_SELECTED,
@@ -308,6 +310,7 @@ class SettingsForm extends Form
         $updateFields = array_values(array_filter([
             $this->getData(Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_TITLE) ? Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_TITLE : null,
             $this->getData(Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_BODY) ? Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_BODY : null,
+            $this->getData(Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_STATUS) ? Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_STATUS : null,
         ]));
 
         $this->plugin->updateSetting(

--- a/classes/Workflow/CodecheckStatusHandler.php
+++ b/classes/Workflow/CodecheckStatusHandler.php
@@ -4,22 +4,27 @@ namespace APP\plugins\generic\codecheck\classes\Workflow;
 
 use Illuminate\Support\Facades\DB;
 use APP\plugins\generic\codecheck\classes\Constants;
+use APP\plugins\generic\codecheck\classes\Log\CodecheckLogger;
 
 class CodecheckStatusHandler {
-    public static function getCurrentStatusData(int $submissionId): object|null {
-        return DB::table('codecheck_status')
+    public static function getCurrentStatusData(int $submissionId): object {
+        $codecheckStatus = DB::table('codecheck_status')
             ->where('submission_id', $submissionId)
             ->orderBy('timestamp', 'desc')
             ->orderBy('status_id', 'desc')
             ->first();
+        
+        return $codecheckStatus ?? (object) ['status' => 'plugins.generic.codecheck.status.pending'];
     }
 
     public static function getStatusDataHistory(int $submissionId): object|null {
-        return DB::table('codecheck_status')
+        $statusHistory = DB::table('codecheck_status')
             ->where('submission_id', $submissionId)
             ->orderBy('timestamp', 'desc')
             ->orderBy('status_id', 'desc')
             ->get();
+
+        return $statusHistory->isEmpty() ? null : $statusHistory;
     }
 
     public static function updateStatus(int $submissionId, string $status, int $userId): object|false {
@@ -43,11 +48,9 @@ class CodecheckStatusHandler {
         $submissionId = $submissionMetadata['submissionId'];
         $statusHistory = CodecheckStatusHandler::getStatusDataHistory($submissionId);
     
-        error_log("Status History: " . json_encode($statusHistory));
-        error_log("Status History count: " . $statusHistory->count());
-        error_log("Is null: " . ($statusHistory === null ? 'true' : 'false'));
+        CodecheckLogger::debug("Status History: " . json_encode($statusHistory));
 
-        if($statusHistory == null || $statusHistory->count() < 2) {
+        if(empty($statusHistory) || $statusHistory->count() < 2) {
             $status = Constants::CODECHECK_STATUS_NEEDS_CODECHECKER;
             if(!empty($submissionMetadata['codecheck']['codecheckers'])) {
                 $status = Constants::CODECHECK_STATUS_ASSIGNED_CODECHECKER;

--- a/cypress/tests/component/CodecheckMetadataForm.cy.js
+++ b/cypress/tests/component/CodecheckMetadataForm.cy.js
@@ -26,7 +26,7 @@ describe('CodecheckMetadataForm Component', () => {
           version: 'latest',
           publicationType: 'doi',
           manifest: [],
-          repository: '',
+          repository: JSON.stringify({ repositories: null, repoWithCodecheckYaml: null }),
           source: '',
           codecheckers: [],
           certificate: '',

--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -119,6 +119,9 @@ msgstr "Update the Issue Title (containing the article's authors)"
 msgid "plugins.generic.codecheck.settings.updateIssue.body"
 msgstr "Update the Issue Description (containing the article, codechecker and repository information)"
 
+msgid "plugins.generic.codecheck.settings.updateIssue.status"
+msgstr "Record & update the CODECHECK Status in the GitHub Register Issue"
+
 msgid "plugins.generic.codecheck.settings.status"
 msgstr "What status must a check have for a submission to proceed with the publication?"
 

--- a/resources/js/Components/CodecheckMetadataForm.vue
+++ b/resources/js/Components/CodecheckMetadataForm.vue
@@ -564,13 +564,13 @@ export default {
           manifestFiles: data.submission?.manifestFiles || '',
           dataAvailabilityStatement: data.submission?.dataAvailabilityStatement || ''
         };
-
-        let repositoryData = typeof data.codecheck.repository === 'string' ? JSON.parse(data.codecheck.repository) :  {
-          repositories: null,
-          repoWithCodecheckYaml: null,
-        };
         
         if (data.codecheck && typeof data.codecheck === 'object') {
+          let repositoryData = typeof data.codecheck.repository === 'string' ? JSON.parse(data.codecheck.repository) :  {
+            repositories: null,
+            repoWithCodecheckYaml: null,
+          };
+
           this.metadata = {
             version: data.codecheck.version || data.codecheck.version || 'latest',
             publicationType: data.codecheck.publicationType || data.codecheck.publication_type || 'doi',

--- a/resources/js/Components/CodecheckStatusForm.vue
+++ b/resources/js/Components/CodecheckStatusForm.vue
@@ -1,9 +1,10 @@
 <template>
     <div class="codecheck-status-form border border-light">
         <div class="flex items-center justify-between bg-default p-5">
-            <h3 class="text-2xl-bold uppercase text-heading">Status</h3>
+            <h3 class="text-2xl-bold uppercase text-heading">{{ t('plugins.generic.codecheck.status') }}</h3>
             <div class="flex gap-x-2">
                 <button
+                    v-if="hasStatusHistory"
                     class="
                         pkpButton
                         inline-flex
@@ -28,7 +29,7 @@
                     {{ t('plugins.generic.codecheck.status.buttons.history') }}
                 </button>
                 <button
-                    v-if="userAllowedToAccess"
+                    v-if="userAllowedToAccess && hasStatusHistory"
                     class="
                         pkpButton
                         pkpButton--isPrimary
@@ -92,6 +93,7 @@ export default {
       statusData: [],
       allStatuses: [],
       userAllowedToAccess: false,
+      hasStatusHistory: false,
     }
   },
   computed: {
@@ -104,6 +106,7 @@ export default {
   },
   mounted() {
     this.validateUserAccessRights();
+    this.getStatusHistory();
     this.loadStatusData();
   },
   watch: {
@@ -222,8 +225,15 @@ export default {
             const data = await response.json();
             const statusHistory = data.statusHistory;
 
+            if(statusHistory === null) {
+                this.hasStatusHistory = false;
+            } else {
+                this.hasStatusHistory = true;
+            }
+
             return statusHistory;
         } catch (error) {
+            this.hasStatusHistory = false;
             console.error('getStatus error:', error);
         }
     },
@@ -282,9 +292,11 @@ export default {
         return table;
     },
     async buildStatusHistoryTable() {
-        const statusHistory = await this.getStatusHistory();
-        const [currentStatus, ...statusRest] = statusHistory;
-        return await this.statusTableSegment([currentStatus], true) + await this.statusTableSegment(statusRest, false);
+        if(this.hasStatusHistory) {
+            const statusHistory = await this.getStatusHistory();
+            const [currentStatus, ...statusRest] = statusHistory;
+            return await this.statusTableSegment([currentStatus], true) + await this.statusTableSegment(statusRest, false);
+        }
     },
     async showHistoryModal() {
       const { useModal } = pkp.modules.useModal;

--- a/templates/settings.tpl
+++ b/templates/settings.tpl
@@ -216,66 +216,6 @@
 							class="pkpFormField__input"
 							value="{$githubRegisterRepository|escape|default:'testing-dev-register'}"
 						/>
-						<button type="button" class="remove pkpButton pkpButton--close">×</button>
-					</div>
-				{/foreach}
-			</div>
-		{/fbvFormSection}
-
-		{* Select which parts of the codecheck GitHub Issue are updated *}
-		{fbvFormSection
-			list=true
-		}
-			<div class="field-header">
-				<label class="pkp_form_label">Update the GitHub Issue</label>
-			</div>
-			<label class="description">Select which information should be updated in the GitHub Register Issue of the CODECHECK</label>
-			{fbvElement
-				type="checkbox"
-				id="updateTitle"
-				checked=$updateTitle
-				label="plugins.generic.codecheck.settings.updateIssue.title"
-			}
-			{fbvElement
-				type="checkbox"
-				id="updateBody"
-				checked=$updateBody
-				label="plugins.generic.codecheck.settings.updateIssue.body"
-			}
-			{fbvElement
-				type="checkbox"
-				id="updateStatus"
-				checked=$updateStatus
-				label="plugins.generic.codecheck.settings.updateIssue.status"
-			}
-		{/fbvFormSection}
-
-		{* Block Publication, when CODECHECK has specific status *}
-		{fbvFormSection
-			list=true
-		}
-			<div class="field-header">
-				<label class="pkp_form_label">{translate key="plugins.generic.codecheck.settings.status"}</label>
-			</div>
-			<label class="description">{translate key="plugins.generic.codecheck.settings.status.description"}</label>
-			<fieldset>
-				<div class="settings-droptown dropdown">
-					<button type="button" class="dropbtn">{translate key="plugins.generic.codecheck.settings.status.selectStatuses"} ⚙</button>
-					<div class="dropdown-content">
-						{foreach from=$codecheckStatuses item=statusKey}
-							<div class="dropdown-checkbox-input">
-								<input
-									type="checkbox"
-									name="codecheckStatusKeysSelected[]"
-									id="status-{$statusKey}"
-									value="{$statusKey|escape}"
-									{if $codecheckStatusKeysSelected && in_array($statusKey, $codecheckStatusKeysSelected)}checked{/if}
-								/>
-								<label for="status-{$statusKey}">
-									{translate key=$statusKey}
-								</label>
-							</div>
-						{/foreach}
 					</div>
 					<button
 					type="button"
@@ -349,8 +289,19 @@
 					checked=$updateBody
 					label="plugins.generic.codecheck.settings.updateIssue.body"
 				}
+				{fbvElement
+					type="checkbox"
+					id="updateStatus"
+					checked=$updateStatus
+					label="plugins.generic.codecheck.settings.updateIssue.status"
+				}
 			{/fbvFormSection}
+		{/fbvFormSection}
 
+		{fbvFormSection list=true}
+			<div class="field-header">
+				<label class="pkp_form_title">{translate key="plugins.generic.codecheck.settings.publication.title"}</label>
+			</div>
 			{* Block Publication, when CODECHECK has specific status *}
 			{fbvFormSection
 				list=true
@@ -381,42 +332,7 @@
 					</div>
 				</fieldset>
 			{/fbvFormSection}
-		{/fbvFormSection}
-
-		{fbvFormSection list=true}
-			<div class="field-header">
-				<label class="pkp_form_title">{translate key="plugins.generic.codecheck.settings.publication.title"}</label>
-			</div>
 			{* Enable extended validation of the CODECHECK metadata to block the publication of the submission *}
-			{fbvFormSection
-				list=true
-			}
-				<div class="field-header">
-					<label class="pkp_form_label">{translate key="plugins.generic.codecheck.settings.status"}</label>
-				</div>
-				<label class="description">{translate key="plugins.generic.codecheck.settings.status.description"}</label>
-				<fieldset>
-					<div class="settings-droptown dropdown">
-						<button type="button" class="dropbtn">{translate key="plugins.generic.codecheck.settings.status.selectStatuses"} ⚙</button>
-						<div class="dropdown-content">
-							{foreach from=$codecheckStatuses item=statusKey}
-								<div class="dropdown-checkbox-input">
-									<input
-										type="checkbox"
-										name="codecheckStatusKeysSelected[]"
-										id="status-{$statusKey}"
-										value="{$statusKey|escape}"
-										{if $codecheckStatusKeysSelected && in_array($statusKey, $codecheckStatusKeysSelected)}checked{/if}
-									/>
-									<label for="status-{$statusKey}">
-										{translate key=$statusKey}
-									</label>
-								</div>
-							{/foreach}
-						</div>
-					</div>
-				</fieldset>
-			{/fbvFormSection}
 			{fbvFormSection
 				list=true
 			}

--- a/templates/settings.tpl
+++ b/templates/settings.tpl
@@ -216,6 +216,66 @@
 							class="pkpFormField__input"
 							value="{$githubRegisterRepository|escape|default:'testing-dev-register'}"
 						/>
+						<button type="button" class="remove pkpButton pkpButton--close">×</button>
+					</div>
+				{/foreach}
+			</div>
+		{/fbvFormSection}
+
+		{* Select which parts of the codecheck GitHub Issue are updated *}
+		{fbvFormSection
+			list=true
+		}
+			<div class="field-header">
+				<label class="pkp_form_label">Update the GitHub Issue</label>
+			</div>
+			<label class="description">Select which information should be updated in the GitHub Register Issue of the CODECHECK</label>
+			{fbvElement
+				type="checkbox"
+				id="updateTitle"
+				checked=$updateTitle
+				label="plugins.generic.codecheck.settings.updateIssue.title"
+			}
+			{fbvElement
+				type="checkbox"
+				id="updateBody"
+				checked=$updateBody
+				label="plugins.generic.codecheck.settings.updateIssue.body"
+			}
+			{fbvElement
+				type="checkbox"
+				id="updateStatus"
+				checked=$updateStatus
+				label="plugins.generic.codecheck.settings.updateIssue.status"
+			}
+		{/fbvFormSection}
+
+		{* Block Publication, when CODECHECK has specific status *}
+		{fbvFormSection
+			list=true
+		}
+			<div class="field-header">
+				<label class="pkp_form_label">{translate key="plugins.generic.codecheck.settings.status"}</label>
+			</div>
+			<label class="description">{translate key="plugins.generic.codecheck.settings.status.description"}</label>
+			<fieldset>
+				<div class="settings-droptown dropdown">
+					<button type="button" class="dropbtn">{translate key="plugins.generic.codecheck.settings.status.selectStatuses"} ⚙</button>
+					<div class="dropdown-content">
+						{foreach from=$codecheckStatuses item=statusKey}
+							<div class="dropdown-checkbox-input">
+								<input
+									type="checkbox"
+									name="codecheckStatusKeysSelected[]"
+									id="status-{$statusKey}"
+									value="{$statusKey|escape}"
+									{if $codecheckStatusKeysSelected && in_array($statusKey, $codecheckStatusKeysSelected)}checked{/if}
+								/>
+								<label for="status-{$statusKey}">
+									{translate key=$statusKey}
+								</label>
+							</div>
+						{/foreach}
 					</div>
 					<button
 					type="button"

--- a/tests/CodecheckRegisterUnitTests/CodecheckGithubRegisterApiClientUnitTest.php
+++ b/tests/CodecheckRegisterUnitTests/CodecheckGithubRegisterApiClientUnitTest.php
@@ -11,6 +11,7 @@ use APP\plugins\generic\codecheck\classes\Exceptions\ApiCreateException;
 use APP\plugins\generic\codecheck\classes\Exceptions\NoMatchingIssuesFoundException;
 use APP\plugins\generic\codecheck\classes\DataStructures\UniqueArray;
 use PKP\tests\PKPTestCase;
+use APP\plugins\generic\codecheck\classes\Constants;
 
 /**
  * @file APP/plugins/generic/codecheck/tests/unittests/CodecheckGithubRegisterApiClientUnitTest.php
@@ -27,6 +28,7 @@ class CodecheckGithubRegisterApiClientUnitTest extends PKPTestCase
     private string $githubRegisterOrganization;
     private string $githubRegisterRepository;
     private string $journalName;
+    private array $updateInformation;
     
     protected function setUp(): void
 	{
@@ -38,6 +40,10 @@ class CodecheckGithubRegisterApiClientUnitTest extends PKPTestCase
         $this->journalName = 'Example journal';
         $this->journal = $this->createMock(\APP\journal\Journal::class);
         $this->journal->method('getLocalizedName')->willReturn($this->journalName);
+        $this->updateInformation = [
+            Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_TITLE,
+            Constants::CODECHECK_GITHUB_REGISTER_ISSUE_UPDATE_BODY,
+        ];
 	}
 
     public function testGithubRegisterClientGetEmptyLabels()
@@ -165,7 +171,8 @@ class CodecheckGithubRegisterApiClientUnitTest extends PKPTestCase
             $authorString,
             $this->submissionId,
             $codecheckers,
-            $repos
+            $repos,
+            $this->updateInformation,
         );
 
         $expectedBody = $issue->getBody();
@@ -207,7 +214,8 @@ class CodecheckGithubRegisterApiClientUnitTest extends PKPTestCase
             $paperTitle,
             $authorString,
             $codecheckers,
-            $repos
+            $repos,
+            $this->updateInformation,
         );
 
         $this->assertEquals(


### PR DESCRIPTION
Closes #132,
closes #141;

! IMPORTANT: Needs #139 to be merged first

- - -

CODECHECK Status Update: Based on the OJS workflow, create a list of "events" that are worth documenting in the register (article reviewed, editorial decisions (reject), certificate published, ...). This is related to https://github.com/codecheckers/ojs-codecheck/issues/32 and what kind of information can be publicly revealed when.

- [x] CODECHECK status should be recorded in the GitHub Issue
- [x] CODECHECK status should be updated in the GitHub Issue
- [x] status update / recording in the issue should be able to be turned off in the plugin settings

- - -

Fix CODECHECK status information, when CODECHECK was not yet started / is pending
- [x] show that status is pending
- [ ] ~act on pending behavior when it is checked if CODECHECK was already started in publication update~