### PR TITLE
feat: deposit register.csv row to CODECHECK Register on publish (closes #10)

### DIFF
--- a/CodecheckPlugin.php
+++ b/CodecheckPlugin.php
@@ -25,6 +25,7 @@ use APP\plugins\generic\codecheck\classes\CodecheckRoles\CodecheckRoleArray;
 use APP\plugins\generic\codecheck\classes\CodecheckRoles\CodecheckRoleManager;
 use APP\plugins\generic\codecheck\classes\Workflow\CodecheckMetadataHandler;
 use APP\plugins\generic\codecheck\classes\Workflow\CodecheckPublicationValidator;
+use APP\plugins\generic\codecheck\classes\Workflow\CodecheckRegisterDepositService;
 use PKP\core\Request;
 use \Github\Client;
 
@@ -80,6 +81,9 @@ class CodecheckPlugin extends GenericPlugin
             // Test if we can hook into the publication to block it if codecheck failed
             Hook::add('Publication::validatePublish', $this->validatePublicationHook(...));
 
+            // Deposit a register.csv row when a CODECHECK-opted-in article is published (Issue #10)
+            Hook::add('Publication::publish', $this->depositToRegister(...));
+
             // Add Localizations to Codecheck Status Preview
             Hook::add('TemplateManager::display', $this->addCodecheckStatusLocalizations(...));
         }
@@ -110,6 +114,47 @@ class CodecheckPlugin extends GenericPlugin
         }
 
         /* Returns `false` to enable OJS itsself and other Plugins to continue with their implementation for this Hook */
+        return false;
+    }
+
+    /**
+     * Deposits a register.csv row to the CODECHECK Register when a
+     * CODECHECK-opted-in submission is published.
+     *
+     * Fires on `Publication::publish`, i.e. after the publication has
+     * actually been saved as published (not during pre-publish validation),
+     * matching the hook signature:
+     *   Hook::call('Publication::publish', [&$newPublication, $publication, $submission]);
+     *
+     * Uses whichever GitHub register organization/repository is already
+     * configured in the plugin settings (see CODECHECK_GITHUB_REGISTER_ORGANIZATION /
+     * CODECHECK_GITHUB_REGISTER_REPOSITORY) — currently defaulting to
+     * codecheckers/testing-dev-register for development.
+     *
+     * @param string $hookName
+     * @param array $args [0] => Publication $newPublication, [1] => Publication $publication, [2] => Submission $submission
+     * @return bool
+     */
+    public function depositToRegister(string $hookName, array $args): bool
+    {
+        [$newPublication, $publication, $submission] = $args;
+
+        if (!$submission->getData('codecheckOptIn')) {
+            return false;
+        }
+
+        CodecheckLogger::debug('Depositing register.csv row for submission #' . $submission->getId());
+
+        $depositService = new CodecheckRegisterDepositService($this);
+        $result = $depositService->depositForSubmission($submission->getId());
+
+        if (!$result['success']) {
+            CodecheckLogger::error('Register deposit failed for submission #' . $submission->getId() . ': ' . ($result['error'] ?? 'unknown error'));
+        }
+
+        // Never block publication on a register-deposit failure — this is a
+        // best-effort side effect, not a publish requirement. Failures are
+        // logged; a manual/CI fallback can pick up the deposit later.
         return false;
     }
 

--- a/classes/CodecheckRegister/CodecheckGithubRegisterApiClient.php
+++ b/classes/CodecheckRegister/CodecheckGithubRegisterApiClient.php
@@ -433,6 +433,12 @@ class CodecheckGithubRegisterApiClient
         $body = "Automated register deposit opened by the OJS CODECHECK plugin on publication.\n\n";
         $body .= "| Column | Value |\n|---|---|\n";
         foreach ($row as $column => $value) {
+            // Turn the Issue number into a full URL so GitHub auto-links this PR
+            // with the corresponding register issue, and posts a backlink comment there too.
+            if ($column === 'Issue' && $value !== 'NA' && ctype_digit((string) $value)) {
+                $issueUrl = "https://github.com/{$this->githubRegisterOrganization}/{$this->githubRegisterRepository}/issues/{$value}";
+                $value = "[#{$value}]({$issueUrl})";
+            }
             $body .= "| $column | $value |\n";
         }
         return $body;

--- a/classes/CodecheckRegister/CodecheckGithubRegisterApiClient.php
+++ b/classes/CodecheckRegister/CodecheckGithubRegisterApiClient.php
@@ -307,6 +307,138 @@ class CodecheckGithubRegisterApiClient
     }
 
     /**
+     * Deposits a new row into the register.csv of the CODECHECK GitHub Register,
+     * by opening a Pull Request against the register repository.
+     *
+     * Flow: fetch current register.csv + its blob sha -> append the new row ->
+     * create a branch off the register's default branch -> commit the updated
+     * file to that branch -> open a PR back to the default branch.
+     *
+     * @param array $row Associative array with keys: Certificate, Repository, Type, Venue, Issue
+     * @param string $certificateIdentifier Used to build a unique branch name and PR title
+     * @return array The created Pull Request's GitHub API response array
+     */
+    public function depositRegisterRow(array $row, string $certificateIdentifier): array
+    {
+        $this->client->authenticate($this->githubPAT, null, Client::AUTH_ACCESS_TOKEN);
+
+        $registerFilePath = 'register.csv';
+
+        // 1. Get the current register.csv content + sha, and the repo's default branch
+        try {
+            $repoInfo = $this->client->api('repo')->show($this->githubRegisterOrganization, $this->githubRegisterRepository);
+            $defaultBranch = $repoInfo['default_branch'] ?? 'main';
+
+            $fileContents = $this->client->api('repo')->contents()->show(
+                $this->githubRegisterOrganization,
+                $this->githubRegisterRepository,
+                $registerFilePath,
+                $defaultBranch
+            );
+        } catch (\Throwable $e) {
+            throw new ApiFetchException("Failed fetching '$registerFilePath' from the register repository.\n" . $e->getMessage());
+        }
+
+        $currentCsv = base64_decode($fileContents['content']);
+        $currentSha = $fileContents['sha'];
+
+        // 2. Append the new row, preserving the existing line-ending style
+        $newCsv = $this->appendCsvRow($currentCsv, $row);
+
+        // 3. Create a new branch off the default branch's current commit
+        $branchName = 'register-deposit/' . preg_replace('/[^A-Za-z0-9_.-]/', '-', $certificateIdentifier);
+
+        try {
+            $baseRef = $this->client->api('gitData')->references()->show(
+                $this->githubRegisterOrganization,
+                $this->githubRegisterRepository,
+                'heads/' . $defaultBranch
+            );
+            $baseSha = $baseRef['object']['sha'];
+
+            $this->client->api('gitData')->references()->create(
+                $this->githubRegisterOrganization,
+                $this->githubRegisterRepository,
+                [
+                    'ref' => 'refs/heads/' . $branchName,
+                    'sha' => $baseSha,
+                ]
+            );
+        } catch (\Throwable $e) {
+            throw new ApiCreateException("Failed creating the branch '$branchName' for the register deposit.\n" . $e->getMessage(), $e->getCode());
+        }
+
+        // 4. Commit the updated register.csv to the new branch
+        try {
+            $this->client->api('repo')->contents()->update(
+                $this->githubRegisterOrganization,
+                $this->githubRegisterRepository,
+                $registerFilePath,
+                $newCsv,
+                'Add register entry for certificate ' . $certificateIdentifier,
+                $currentSha,
+                $branchName
+            );
+        } catch (\Throwable $e) {
+            throw new ApiUpdateException("Failed committing the updated '$registerFilePath' to branch '$branchName'.\n" . $e->getMessage(), $e->getCode());
+        }
+
+        // 5. Open the Pull Request
+        try {
+            $pullRequest = $this->client->api('pull_request')->create(
+                $this->githubRegisterOrganization,
+                $this->githubRegisterRepository,
+                [
+                    'base' => $defaultBranch,
+                    'head' => $branchName,
+                    'title' => 'Register deposit: certificate ' . $certificateIdentifier,
+                    'body' => $this->buildDepositPrBody($row),
+                ]
+            );
+        } catch (\Throwable $e) {
+            throw new ApiCreateException("Failed opening the Pull Request for the register deposit.\n" . $e->getMessage(), $e->getCode());
+        }
+
+        return $pullRequest;
+    }
+
+    /**
+     * Appends a single row to CSV content, matching the existing header's
+     * column order and preserving the file's trailing-newline style.
+     */
+    private function appendCsvRow(string $currentCsv, array $row): string
+    {
+        $hadTrailingNewline = str_ends_with($currentCsv, "\n");
+        $lines = explode("\n", rtrim($currentCsv, "\n"));
+
+        $header = str_getcsv($lines[0]);
+
+        $newLineValues = [];
+        foreach ($header as $column) {
+            $newLineValues[] = $row[$column] ?? '';
+        }
+
+        $newLine = implode(',', array_map(
+            fn($value) => str_contains($value, ',') ? '"' . str_replace('"', '""', $value) . '"' : $value,
+            $newLineValues
+        ));
+
+        $lines[] = $newLine;
+
+        return implode("\n", $lines) . ($hadTrailingNewline ? "\n" : '');
+    }
+
+    private function buildDepositPrBody(array $row): string
+    {
+        $body = "Automated register deposit opened by the OJS CODECHECK plugin on publication.\n\n";
+        $body .= "| Column | Value |\n|---|---|\n";
+        foreach ($row as $column => $value) {
+            $body .= "| $column | $value |\n";
+        }
+        return $body;
+    }
+
+    /**
      * Gets all fetched CODECHECK GtiHub Register Issues
      * 
      * @return array Returns an array of all CODECHECK GtiHub Register Issues

--- a/classes/Workflow/CodecheckRegisterDepositService.php
+++ b/classes/Workflow/CodecheckRegisterDepositService.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace APP\plugins\generic\codecheck\classes\Workflow;
+
+use APP\core\Application;
+use APP\core\Request;
+use APP\facades\Repo;
+use Illuminate\Support\Facades\DB;
+use APP\plugins\generic\codecheck\CodecheckPlugin;
+use APP\plugins\generic\codecheck\classes\Constants;
+use APP\plugins\generic\codecheck\classes\Log\CodecheckLogger;
+use APP\plugins\generic\codecheck\classes\Workflow\CodecheckMetadataHandler;
+use APP\plugins\generic\codecheck\classes\CodecheckRegister\CodecheckGithubRegisterApiClient;
+use APP\plugins\generic\codecheck\classes\Exceptions\GithubUrlParseException;
+use \Github\Client;
+
+/**
+ * Assembles the register.csv row for a published CODECHECK and deposits it
+ * to the CODECHECK Register (see ojs-codecheck#10).
+ *
+ * This class is intentionally read-mostly with respect to existing plugin
+ * state: it reuses `CodecheckMetadataHandler` for all data access instead
+ * of querying `codecheck_metadata` directly, and reuses
+ * `CodecheckGithubRegisterApiClient::parseGithubUrl()` for GitHub URL
+ * parsing rather than re-implementing it.
+ */
+class CodecheckRegisterDepositService
+{
+    private CodecheckPlugin $plugin;
+    private Request $request;
+    private CodecheckMetadataHandler $codecheckMetadataHandler;
+    private array $errors = [];
+
+    public function __construct(CodecheckPlugin $plugin)
+    {
+        $this->plugin = $plugin;
+        $this->request = Application::get()->getRequest();
+        $this->codecheckMetadataHandler = new CodecheckMetadataHandler($this->request, new Client());
+    }
+
+    /**
+     * Entry point: build the register row for a submission and open a PR
+     * against the configured register repository.
+     *
+     * @param int $submissionId
+     * @return array{success: bool, prUrl?: string, row?: array, error?: string}
+     */
+    public function depositForSubmission(int $submissionId): array
+    {
+        $this->errors = [];
+
+        $submission = Repo::submission()->get($submissionId);
+        if (!$submission) {
+            return $this->fail("Submission #$submissionId not found.");
+        }
+
+        $metadataResult = $this->codecheckMetadataHandler->getMetadata($this->request, $submissionId);
+
+        if (isset($metadataResult['error']) || empty($metadataResult['codecheck'])) {
+            return $this->fail('No CODECHECK metadata found for submission #' . $submissionId . '.');
+        }
+
+        $codecheckMetadata = $metadataResult['codecheck'];
+
+        // Certificate is required to deposit at all.
+        $certificate = $codecheckMetadata['certificate'] ?? null;
+        if (empty($certificate)) {
+            return $this->fail('No Certificate Identifier has been reserved for submission #' . $submissionId . '.');
+        }
+
+        // Resolve which repository the codechecker marked as containing codecheck.yml.
+        $repositoryUrl = $this->resolveSelectedRepositoryUrl($codecheckMetadata);
+        if ($repositoryUrl === null) {
+            return $this->fail(
+                'No repository containing the codecheck.yml file was selected for submission #' . $submissionId . '. ' .
+                'The codechecker must check "Contains codecheck.yml file" for one of the listed repositories before publication.'
+            );
+        }
+
+        // Re-run the same import/fetch check already used elsewhere in the plugin
+        // (checkbox-time validation, extended publication validation) so a stale
+        // or unreachable URL never reaches the public register, independent of
+        // whether the journal has "extended validation" turned on.
+        $importResponse = $this->codecheckMetadataHandler->importMetadataFromRepository($repositoryUrl);
+        if (!$importResponse->isSuccess()) {
+            $payload = $importResponse->getPayloadArray();
+            return $this->fail(
+                'Could not verify the codecheck.yml at "' . $repositoryUrl . '": ' . ($payload['error'] ?? 'unknown error')
+            );
+        }
+
+        // Convert the URL into the register's `Repository` column format
+        // (e.g. github::org/repo, zenodo::id, osf::id, gitlab::path).
+        try {
+            $formattedRepository = $this->formatRepositoryForRegister($repositoryUrl);
+        } catch (\Throwable $e) {
+            return $this->fail('Could not format repository "' . $repositoryUrl . '" for the register: ' . $e->getMessage());
+        }
+
+        $row = $this->buildRegisterRow($submission, $codecheckMetadata, $certificate, $formattedRepository);
+
+        $context = $this->request->getContext();
+        $githubPersonalAccessToken = $this->plugin->getSetting($context->getId(), Constants::CODECHECK_GITHUB_PERSONAL_ACCESS_TOKEN);
+        $githubRegisterOrganization = $this->plugin->getSetting($context->getId(), Constants::CODECHECK_GITHUB_REGISTER_ORGANIZATION);
+        $githubRegisterRepository = $this->plugin->getSetting($context->getId(), Constants::CODECHECK_GITHUB_REGISTER_REPOSITORY);
+
+        $codecheckGithubRegisterApiClient = new CodecheckGithubRegisterApiClient(
+            $githubPersonalAccessToken,
+            $githubRegisterOrganization,
+            $githubRegisterRepository,
+            (string) $submissionId,
+            $context,
+        );
+
+        try {
+            $pullRequest = $codecheckGithubRegisterApiClient->depositRegisterRow($row, $certificate);
+        } catch (\Throwable $e) {
+            CodecheckLogger::error('Register deposit failed for submission #' . $submissionId . ': ' . $e->getMessage());
+            return $this->fail('Failed to open the register deposit Pull Request: ' . $e->getMessage());
+        }
+
+        CodecheckLogger::info('Register deposit PR opened for submission #' . $submissionId . ': ' . $pullRequest['html_url']);
+
+        return [
+            'success' => true,
+            'prUrl' => $pullRequest['html_url'],
+            'row' => $row,
+        ];
+    }
+
+    /**
+     * Resolve `repoWithCodecheckYaml` (an index into the comma-separated
+     * `repositories` string) into the actual URL string.
+     */
+    private function resolveSelectedRepositoryUrl(array $codecheckMetadata): ?string
+    {
+        $repositoryData = $codecheckMetadata['repository'] ?? null;
+
+        if (!is_array($repositoryData) || empty($repositoryData['repositories'])) {
+            return null;
+        }
+
+        $index = $repositoryData['repoWithCodecheckYaml'] ?? null;
+        if (!is_int($index)) {
+            return null;
+        }
+
+        $repositories = array_map('trim', explode(',', $repositoryData['repositories']));
+
+        return $repositories[$index] ?? null;
+    }
+
+    /**
+     * Converts a raw repository URL into the register.csv `Repository`
+     * column format, e.g.:
+     *   https://github.com/codecheckers/certificate-2025-029        -> github::codecheckers/certificate-2025-029
+     *   https://github.com/org/repo/blob/main/reports/08/codecheck.yml -> github::org/repo|reports/08
+     *   https://zenodo.org/records/12345678                          -> zenodo::12345678
+     *   https://osf.io/abcde/                                        -> osf::abcde
+     *   https://gitlab.com/cdchck/community-codechecks/some-check    -> gitlab::some-check
+     */
+    private function formatRepositoryForRegister(string $repository): string
+    {
+        if (preg_match('#^https://github\.com/#', $repository)) {
+            $parts = CodecheckGithubRegisterApiClient::parseGithubUrl($repository);
+            $formatted = "github::{$parts['owner']}/{$parts['repo']}";
+            if (!empty($parts['path'])) {
+                // Register convention for a sub-path within a shared repository,
+                // e.g. github::reproducible-agile/reviews-2025|reports/08
+                $formatted .= '|' . $parts['path'];
+            }
+            return $formatted;
+        }
+
+        if (preg_match('#^https://zenodo\.org/records/(\d+)/?$#', $repository, $matches)) {
+            return "zenodo::{$matches[1]}";
+        }
+
+        if (preg_match('#^https://osf\.io/([A-Za-z0-9]{5})/?$#', $repository, $matches)) {
+            return "osf::{$matches[1]}";
+        }
+
+        if (preg_match('#^https://gitlab\.com/cdchck/community-codechecks/([^/]+)/?$#', $repository, $matches)) {
+            return "gitlab::{$matches[1]}";
+        }
+
+        throw new GithubUrlParseException("Repository URL \"$repository\" does not match any register-supported format.");
+    }
+
+    /**
+     * Assemble the 5-column register.csv row: Certificate, Repository, Type, Venue, Issue.
+     */
+    private function buildRegisterRow($submission, array $codecheckMetadata, string $certificate, string $formattedRepository): array
+    {
+        $context = $this->request->getContext();
+        $issueData = $codecheckMetadata['issue'] ?? [];
+        $issueNumber = $issueData['number'] ?? null;
+
+        return [
+            'Certificate' => $certificate,
+            'Repository' => $formattedRepository,
+            'Type' => 'journal',
+            'Venue' => $context?->getLocalizedName() ?? 'Unknown Journal',
+            'Issue' => $issueNumber !== null ? (string) $issueNumber : 'NA',
+        ];
+    }
+
+    private function fail(string $message): array
+    {
+        $this->errors[] = $message;
+        CodecheckLogger::error('CODECHECK Register Deposit: ' . $message);
+
+        return [
+            'success' => false,
+            'error' => $message,
+        ];
+    }
+
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}


### PR DESCRIPTION
This PR is built on top of #139 (repository-selection / `repoWithCodecheckYaml`) and should be merged after it.

## Summary
When a CODECHECK-opted-in article is published, the plugin now automatically opens a PR against the CODECHECK Register adding a row for it, closing #10.

## What this adds
- **`CodecheckRegisterDepositService`** — resolves the repository the codechecker marked as containing `codecheck.yml` (from #139), re-validates it, formats it for the register (`github::org/repo`, `zenodo::id`, `osf::id`, `gitlab::path`), and builds the row.
- **`CodecheckGithubRegisterApiClient::depositRegisterRow()`** — appends the row to `register.csv` and opens a PR against the configured register repo.
- **`CodecheckPlugin::depositToRegister()`** — hooked into `Publication::publish`; runs for opted-in submissions; never blocks publication if the deposit fails.

## Tested against
`codecheckers/testing-dev-register`, using `codecheckers/driftage` as an existing repo with a real `codecheck.yml`. Working example: https://github.com/codecheckers/testing-dev-register/pull/176

## How to test
1. Set an opted-in submission's title to match an existing `codecheck.yml` in a `codecheckers/*` repo (or your own Zenodo/OSF record).
2. Add that repository, check "Contains codecheck.yml file," reserve a certificate identifier.
3. Publish, then check the logs and `testing-dev-register`'s open PRs.

<img width="643" height="166" alt="image" src="https://github.com/user-attachments/assets/ce9bac0a-01a0-4c78-9f73-e4785f502368" />


<img width="2560" height="1184" alt="image" src="https://github.com/user-attachments/assets/1be4e134-1fdb-49bd-abda-f98a4bd15f6f" />
