### PR TITLE
feat: settings toggle and register.csv warning for register deposit

### DIFF
--- a/CodecheckPlugin.php
+++ b/CodecheckPlugin.php
@@ -142,6 +142,12 @@ class CodecheckPlugin extends GenericPlugin
             return false;
         }
 
+        $context = Application::get()->getRequest()->getContext();
+        if (!$this->getSetting($context->getId(), Constants::CODECHECK_REGISTER_DEPOSIT_ENABLED)) {
+            CodecheckLogger::debug('Register deposit is disabled for this journal; skipping for submission #' . $submission->getId());
+            return false;
+        }
+
         CodecheckLogger::debug('Depositing register.csv row for submission #' . $submission->getId());
 
         $depositService = new CodecheckRegisterDepositService($this);

--- a/classes/Constants.php
+++ b/classes/Constants.php
@@ -81,4 +81,7 @@ class Constants
     public const CODECHECK_STATUS_KEYS_SELECTED = 'codecheckStatusKeysSelected';
     # Extended Validation
     public const CODECHECK_PUBLICATION_VALIDATION_EXTENDED = 'codecheckPublicationExtendedValidation';
+
+    # Register Deposit (Issue #10)
+    public const CODECHECK_REGISTER_DEPOSIT_ENABLED = 'codecheckRegisterDepositEnabled';
 }

--- a/classes/Settings/SettingsForm.php
+++ b/classes/Settings/SettingsForm.php
@@ -149,6 +149,16 @@ class SettingsForm extends Form
             ) ?? []
         );
 
+        // Default to true — register deposit runs unless explicitly disabled
+        $registerDepositEnabled = $this->plugin->getSetting(
+            $context->getId(),
+            Constants::CODECHECK_REGISTER_DEPOSIT_ENABLED
+        );
+        $this->setData(
+            Constants::CODECHECK_REGISTER_DEPOSIT_ENABLED,
+            $registerDepositEnabled === null ? true : (bool) $registerDepositEnabled
+        );
+
         // Default to true — show the dashboard column unless explicitly disabled
         $showDashboardColumn = $this->plugin->getSetting(
             $context->getId(),
@@ -207,6 +217,7 @@ class SettingsForm extends Form
             Constants::CODECHECK_STATUSES_SELECTED,
             Constants::CODECHECK_STATUS_KEYS_SELECTED,
             Constants::CODECHECK_PUBLICATION_VALIDATION_EXTENDED,
+            Constants::CODECHECK_REGISTER_DEPOSIT_ENABLED,
         ]);
 
         parent::readInputData();
@@ -307,6 +318,12 @@ class SettingsForm extends Form
             $context->getId(),
             Constants::CODECHECK_GITHUB_REGISTER_REPOSITORY,
             $this->getData(Constants::CODECHECK_GITHUB_REGISTER_REPOSITORY)
+        );
+
+        $this->plugin->updateSetting(
+            $context->getId(),
+            Constants::CODECHECK_REGISTER_DEPOSIT_ENABLED,
+            (bool) $this->getData(Constants::CODECHECK_REGISTER_DEPOSIT_ENABLED)
         );
 
         $registerWarning = $this->validateRegisterFileExists(

--- a/classes/Settings/SettingsForm.php
+++ b/classes/Settings/SettingsForm.php
@@ -20,6 +20,7 @@ use APP\template\TemplateManager;
 use PKP\form\Form;
 use PKP\form\validation\FormValidatorCSRF;
 use PKP\form\validation\FormValidatorPost;
+use Github\Client;
 
 class SettingsForm extends Form
 {
@@ -308,6 +309,20 @@ class SettingsForm extends Form
             $this->getData(Constants::CODECHECK_GITHUB_REGISTER_REPOSITORY)
         );
 
+        $registerWarning = $this->validateRegisterFileExists(
+            $this->getData(Constants::CODECHECK_GITHUB_REGISTER_ORGANIZATION),
+            $this->getData(Constants::CODECHECK_GITHUB_REGISTER_REPOSITORY)
+        );
+
+        if ($registerWarning !== null) {
+            $notificationMgr = new NotificationManager();
+            $notificationMgr->createTrivialNotification(
+                Application::get()->getRequest()->getUser()->getId(),
+                Notification::NOTIFICATION_TYPE_WARNING,
+                ['contents' => $registerWarning]
+            );
+        }
+
         $this->plugin->updateSetting(
             $context->getId(),
             Constants::CODECHECK_GITHUB_CUSTOM_LABELS,
@@ -373,5 +388,28 @@ class SettingsForm extends Form
         );
 
         return parent::execute();
+    }
+
+    /**
+     * Checks whether `register.csv` exists at the root of the configured
+     * GitHub register repository, so a misconfigured target is caught at
+     * settings-save time instead of silently failing on the next publish.
+     */
+    private function validateRegisterFileExists(string $organization, string $repository): ?string
+    {
+        if (empty($organization) || empty($repository)) {
+            return null; // nothing to check yet
+        }
+
+        try {
+            $client = new Client();
+            $client->api('repo')->contents()->show($organization, $repository, 'register.csv');
+            return null; // found, no warning needed
+        } catch (\Throwable $e) {
+            return __('plugins.generic.codecheck.settings.github.registerRepository.missingCsvWarning', [
+                'organization' => $organization,
+                'repository' => $repository,
+            ]);
+        }
     }
 }

--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -843,3 +843,12 @@ msgstr "Register Repository: {$repository}"
 
 msgid "plugins.generic.codecheck.settings.github.registerRepository.missingCsvWarning"
 msgstr "Warning: no register.csv was found at the root of {$organization}/{$repository}. Register deposits will fail until this file exists there."
+
+msgid "plugins.generic.codecheck.settings.registerDeposit.title"
+msgstr "Register Deposit"
+
+msgid "plugins.generic.codecheck.settings.registerDeposit.description"
+msgstr "When enabled, publishing a CODECHECK-opted-in submission will automatically open a Pull Request adding a row to the CODECHECK Register's register.csv file."
+
+msgid "plugins.generic.codecheck.settings.registerDeposit.checkboxText"
+msgstr "Automatically deposit to the CODECHECK Register on publication"

--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -840,3 +840,6 @@ msgstr "not set"
 
 msgid "plugins.generic.codecheck.github.issue.display.registerRepository"
 msgstr "Register Repository: {$repository}"
+
+msgid "plugins.generic.codecheck.settings.github.registerRepository.missingCsvWarning"
+msgstr "Warning: no register.csv was found at the root of {$organization}/{$repository}. Register deposits will fail until this file exists there."

--- a/templates/settings.tpl
+++ b/templates/settings.tpl
@@ -361,6 +361,22 @@
 					label="plugins.generic.codecheck.settings.publication.extendedValidation.checkboxText"
 				}
 			{/fbvFormSection}
+
+			{* Enable automatic register.csv deposit on publication (Issue #10) *}
+			{fbvFormSection
+				list=true
+			}
+				<div class="field-header">
+					<label class="pkp_form_label">{translate key="plugins.generic.codecheck.settings.registerDeposit.title"}</label>
+				</div>
+				<label class="description">{translate key="plugins.generic.codecheck.settings.registerDeposit.description"}</label>
+				{fbvElement
+					type="checkbox"
+					id="codecheckRegisterDepositEnabled"
+					checked=$codecheckRegisterDepositEnabled
+					label="plugins.generic.codecheck.settings.registerDeposit.checkboxText"
+				}
+			{/fbvFormSection}
 		{/fbvFormSection}
 
 		{* TODO: Add more settings in future development *}


### PR DESCRIPTION
## Summary
Two small additions to the register deposit feature (#10), based on feedback:

- Warn on settings save if `register.csv` doesn't exist at the configured register org/repo, instead of only failing silently on the next publish.
- Add a settings checkbox to enable/disable automatic register deposit per journal (previously always-on).

<img width="1367" height="121" alt="image" src="https://github.com/user-attachments/assets/a64848e5-3427-48e6-a7af-5fea54cb0f20" />
